### PR TITLE
Add storage tier to flexible postgres

### DIFF
--- a/examples/complete/providers.tf
+++ b/examples/complete/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "=3.73.0"
+      version = "=3.104.2"
     }
 
     vault = {

--- a/flexible_server.tf
+++ b/flexible_server.tf
@@ -1,6 +1,7 @@
 resource "azurerm_postgresql_flexible_server" "flexible_server" {
   count               = var.single_server ? 0 : 1
   name                = var.server_name
+  storage_tier        = var.storage_tier
   location            = var.location
   resource_group_name = var.resource_group_name
 

--- a/variables.tf
+++ b/variables.tf
@@ -21,6 +21,7 @@ variable "server_name" {
 variable "storage_tier" {
   description = "Specifies the name of the Storage Tier. Changing this forces a new resource to be created."
   type        = string
+  default     = "P15"
 }
 
 variable "create_mode" {

--- a/variables.tf
+++ b/variables.tf
@@ -21,7 +21,7 @@ variable "server_name" {
 variable "storage_tier" {
   description = "Specifies the name of the Storage Tier. Changing this forces a new resource to be created."
   type        = string
-  default     = "P15"
+  default     = "P10"
 }
 
 variable "create_mode" {

--- a/variables.tf
+++ b/variables.tf
@@ -18,6 +18,11 @@ variable "server_name" {
   type        = string
 }
 
+variable "storage_tier" {
+  description = "Specifies the name of the Storage Tier. Changing this forces a new resource to be created."
+  type        = string
+}
+
 variable "create_mode" {
   description = "The creation mode which can be used to restore or replicate existing servers"
   type        = string


### PR DESCRIPTION
<!---
Please add this into the test of test/fixture, format the changes by "terraform fmt", and test it by run the following:
```sh
$ docker build --build-arg BUILD_ARM_SUBSCRIPTION_ID=$ARM_SUBSCRIPTION_ID --build-arg BUILD_ARM_CLIENT_ID=$ARM_CLIENT_ID --build-arg BUILD_ARM_CLIENT_SECRET=$ARM_CLIENT_SECRET --build-arg BUILD_ARM_TENANT_ID=$ARM_TENANT_ID -t azure-postgresql .
$ docker run --rm azure-postgresql /bin/bash -c "bundle install && rake full"
```
Please add this into the example usage of README.md and format the changes by "terrafmt fmt README.md". Please intall "terrafmt" by [install terrafmt](https://github.com/katbyte/terrafmt#install).
--->

Fixes #000

Changes proposed in the pull request:
