### PR TITLE
DTSPO-31039 - Update agent pool to new CIS-hardened Ubuntu VMSS

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ resources:
 extends:
   template: pipelines/terratest.yaml@cppAzureDevOpsTemplates
   parameters:
-    agentPool: "MDV-ADO-AGENTS-01"
+    agentPool: "ubuntu-ado-agents-mdv"
     azureServiceConnection: "ado_nonlive_workload_identity"
     terratestTimeout: "60"
     tfversion: 1.7.5

--- a/backup.tf
+++ b/backup.tf
@@ -4,7 +4,7 @@ locals {
   enable_backup_enrollment = var.service_criticality >= 4 && !var.single_server
 
   # Construct backup policy ID from vault ID and policy name
-  
+
   backup_policy_id = local.enable_backup_enrollment && length(data.azurerm_data_protection_backup_vault.vault) > 0 ? ("${data.azurerm_data_protection_backup_vault.vault[0].id}/backupPolicies/${var.backup_policy_name}") : null
 
 }


### PR DESCRIPTION

https://tools.hmcts.net/jira/browse/DTSPO-31039

Replace end-of-life MDV-ADO-AGENTS-01 pool with the new ubuntu-ado-agents-mdv VMSS pool in the pipeline.

<!---
Please add this into the test of test/fixture, format the changes by "terraform fmt", and test it by run the following:
```sh
$ docker build --build-arg BUILD_ARM_SUBSCRIPTION_ID=$ARM_SUBSCRIPTION_ID --build-arg BUILD_ARM_CLIENT_ID=$ARM_CLIENT_ID --build-arg BUILD_ARM_CLIENT_SECRET=$ARM_CLIENT_SECRET --build-arg BUILD_ARM_TENANT_ID=$ARM_TENANT_ID -t azure-postgresql .
$ docker run --rm azure-postgresql /bin/bash -c "bundle install && rake full"
```
Please add this into the example usage of README.md and format the changes by "terrafmt fmt README.md". Please intall "terrafmt" by [install terrafmt](https://github.com/katbyte/terrafmt#install).
--->

Fixes #000

Changes proposed in the pull request:
